### PR TITLE
Execute asynchronously and allow adding extra arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
                 "open-in-vim.integrated-terminal.pathToShell": {
                     "type": "string",
                     "default": null,
-                    "definition": "Path to unix shell which will host the vim process."
+                    "description": "Path to unix shell which will host the vim process."
                 },
                 "open-in-vim.linux.gnome-terminal.args": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
                     "scope": "resource",
                     "default": "default profile",
                     "description": "Profile to use for iterm window"
+                },
+                "open-in-vim.extraArgs": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Extra arguments to pass to vim"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
                 },
                 "open-in-vim.extraArgs": {
                     "type": "string",
-                    "default": null,
+                    "default": "",
                     "description": "Extra arguments to pass to vim"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
                     "default": false,
                     "description": "(EXPERIMENTAL) Sync cursor position to vscode when vim quits"
                 },
+                "open-in-vim.synchronous": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Run only one instance at a time"
+                },
                 "open-in-vim.integrated-terminal.pathToShell": {
                     "type": "string",
                     "default": null,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,8 @@ type Config = {
         iterm: {
             profile: string;
         }
-    }
+    },
+    extraArgs: string
 };
 const PATH_TO_WINDOWS_GIT_SHELL = 'C:\\Program Files\\Git\\bin\\bash.exe';
 function getConfiguration(): Config {
@@ -79,7 +80,7 @@ function getConfiguration(): Config {
 }
 
 function openInVim() {
-    const { openMethod, useNeovim, restoreCursorAfterVim } = getConfiguration();
+    const { openMethod, useNeovim, restoreCursorAfterVim, extraArgs } = getConfiguration();
 
     let activeTextEditor = vscode.window.activeTextEditor;
     if (!activeTextEditor) {
@@ -126,7 +127,7 @@ function openInVim() {
         vim: useNeovim ? 'nvim' : 'vim',
         fileName: fileName,
         // cannot contain double quotes
-        args: `'+call cursor(${line}, ${column})' ${restoreCursorAfterVim ? autocmdArgToSyncCursor : ''}; exit`,
+        args: `'+call cursor(${line}, ${column})' ${restoreCursorAfterVim ? autocmdArgToSyncCursor : ''} ${extraArgs}`,
         workspacePath,
     });
 }
@@ -145,7 +146,7 @@ type OpenMethods = {
 };
 
 function openArgsToCommand(openArgs: OpenMethodsArgument) {
-    return `${openArgs.vim} '${openArgs.fileName}' ${openArgs.args}`;
+    return `${openArgs.vim} ${openArgs.args} '${openArgs.fileName}'`;
 }
 
 function openArgsToScriptFile(openArgs: OpenMethodsArgument) {


### PR DESCRIPTION
I wanted to run one instance of Vim and switch between both editors without having to close Vim every time.
To achieve this I've added the `synchronous` checkbox to use `exec` instead of `execSync` and the `extraArgs` field to add `--servername vscode --remote-silent` to the parameters so only one instance of Vim is used.

I've just tested it with MacVim but seems to work nicely.